### PR TITLE
Feature: Add option to save the generated molecules as an SDF file

### DIFF
--- a/semlaflow/predict.py
+++ b/semlaflow/predict.py
@@ -274,9 +274,9 @@ def generate_smol_mols(output, model):
 
 def save_predictions(args, molecules, raw_outputs, model):
     save_path = Path(args.save_dir) / args.save_file
+    save_path.parent.mkdir(parents=True, exist_ok=True)
 
     if args.save_file.endswith(".sdf"):
-        save_path.parent.mkdir(parents=True, exist_ok=True)
         return write_mols_to_sdf(molecules, str(save_path))
 
     # Generate GeometricMols and then combine into one GeometricMolBatch

--- a/semlaflow/util/rdkit.py
+++ b/semlaflow/util/rdkit.py
@@ -408,6 +408,8 @@ def write_mols_to_sdf(mols: list[Chem.rdchem.Mol], filename: str):
 
     writer = Chem.SDWriter(filename)
     for mol in mols:
+        if mol is None:
+            continue
         writer.write(mol)
 
     writer.close()

--- a/semlaflow/util/rdkit.py
+++ b/semlaflow/util/rdkit.py
@@ -396,3 +396,18 @@ def _infer_bonds(mol: Chem.rdchem.Mol):
     mol_str = pybel_mol.write("mol")
     mol = Chem.MolFromMolBlock(mol_str, removeHs=False, sanitize=True)
     return mol
+
+
+def write_mols_to_sdf(mols: list[Chem.rdchem.Mol], filename: str):
+    """Write a list of RDKit molecules to an SDF file
+
+    Args:
+        mols: List of RDKit molecules
+        filename: Path to write the SDF file
+    """
+
+    writer = Chem.SDWriter(filename)
+    for mol in mols:
+        writer.write(mol)
+
+    writer.close()


### PR DESCRIPTION
Saving the generated molecules to a standard file format is beneficial for downstream tasks. This PR adds the option to save the generated molecules as an SDF file. 

Changes: 
- Adds functionality to `semlaflow.predict.save_predictions` to write molecules to an SDF file if the provided file name ends with `.sdf`.
- Introduces `semlaflow.util.write_mols_to_sdf`, which wraps the RDKit's `SDWriter` class for SDF file generation.

Example usage:
```
python -m semlaflow.predict --data_path=data/qm9/smol --ckpt_path models/qm9/300epochs.ckpt --dataset=qm9 --save_dir=predictions/qm9 --save_file=predictions.sdf
```
This command will generate the file `predictions/qm9/predictions.sdf`, containing the generated molecules.
